### PR TITLE
Re-phrase docs of set_content behavior for str payloads

### DIFF
--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -156,7 +156,13 @@ Currently the email package provides only one concrete content manager,
        :exc:`ValueError`.
 
        * For ``str`` objects, if *cte* is not set use heuristics to
-         determine the most compact encoding.
+         determine the most compact encoding.  Prior to encoding,
+         :meth:`str.splitlines` is used to normalize all line boundaries,
+         ensuring that each line of the payload is terminated by the
+         current policy's :data:`~email.policy.Policy.linesep` property
+         (even if the original string did not end with one).
+       * For ``bytes`` objects, *cte* is taken to be base64 if not set,
+         and the aforementioned newline translation is not performed.
        * For :class:`~email.message.EmailMessage`, per :rfc:`2046`, raise
          an error if a *cte* of ``quoted-printable`` or ``base64`` is
          requested for *subtype* ``rfc822``, and for any *cte* other than
@@ -190,13 +196,6 @@ Currently the email package provides only one concrete content manager,
        ``headername: headervalue`` or a list of ``header`` objects
        (distinguished from strings by having a ``name`` attribute), add the
        headers to *msg*.
-
-       Note that this method will append a newline character to the end of strings,
-       if it wasn't passed already. For example, the following are equivalent ::
-
-         msg = EmailMessage()
-         msg.set_content("hello")
-         msg.set_content("hello\n")
 
 
 .. rubric:: Footnotes


### PR DESCRIPTION
Patch for [gh-121543](https://github.com/python/cpython/pull/121543)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--2.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->