### PR TITLE
Reorganize compiler flag docs

### DIFF
--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -333,8 +333,6 @@ the same library that the Python runtime is using.
    equal to ``0``, and any modification due to ``from __future__ import`` is
    discarded.
 
-   The available :ref:`compiler flags <ast-compiler-flags>` are accessible as macros.
-
    .. c:member:: int cf_flags
 
       Compiler flags.
@@ -350,23 +348,20 @@ the same library that the Python runtime is using.
    .. versionchanged:: 3.8
       Added *cf_feature_version* field.
 
-.. c:macro:: PyCF_ALLOW_TOP_LEVEL_AWAIT
+   The available compiler flags are accessible as macros:
 
-   Equivalent to :data:`ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`.
+   .. c:namespace:: NULL
 
-.. c:macro:: PyCF_ONLY_AST
+   .. c:macro:: PyCF_ALLOW_TOP_LEVEL_AWAIT
+                PyCF_ONLY_AST
+                PyCF_OPTIMIZED_AST
+                PyCF_TYPE_COMMENTS
 
-   Equivalent to :data:`ast.PyCF_ONLY_AST`.
+      See :ref:`compiler flags <ast-compiler-flags>` in documentation of the
+      :py:mod:`!ast` Python module, which exports these constants under
+      the same names.
 
-.. c:macro:: PyCF_OPTIMIZED_AST
+   .. c:var:: int CO_FUTURE_DIVISION
 
-   Equivalent to :data:`ast.PyCF_OPTIMIZED_AST`.
-
-.. c:macro:: PyCF_TYPE_COMMENTS
-
-   Equivalent to :data:`ast.PyCF_TYPE_COMMENTS`.
-
-.. c:var:: int CO_FUTURE_DIVISION
-
-   This bit can be set in *flags* to cause division operator ``/`` to be
-   interpreted as "true division" according to :pep:`238`.
+      This bit can be set in *flags* to cause division operator ``/`` to be
+      interpreted as "true division" according to :pep:`238`.


### PR DESCRIPTION
- Move the constants to the struct that uses them
- Merge definitions to remove unneeded duplication (while keeping `.. c:macro::`, so we get machine-readable metadata saying these are the docs for the C macros)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--3.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->