### PR TITLE
PEP 828: Fix `yield from` not working on non-iterator iterables inside async generators

### DIFF
--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -2716,24 +2716,23 @@ PyTypeObject _PyAsyncGenYieldFrom_Type = {
 
 
 PyObject *
-_PyAsyncGenYieldFrom_New(PyThreadState *tstate, PyObject *iterator)
+_PyAsyncGenYieldFrom_New(PyThreadState *tstate, PyObject *iterable)
 {
     assert(tstate != NULL);
-    assert(iterator != NULL);
+    assert(iterable != NULL);
     _PyAsyncGenYieldFrom *yield_from = PyObject_GC_New(_PyAsyncGenYieldFrom,
                                                       &_PyAsyncGenYieldFrom_Type);
     if (yield_from == NULL) {
         return NULL;
     }
-    if (!PyIter_Check(iterator)) {
-        if (PyAsyncGen_CheckExact(iterator)) {
-            _PyErr_Format(tstate, PyExc_TypeError,
-                          "%T object is not iterable. Did you mean 'async yield from'?",
-                          iterator);
-        } else {
-            _PyErr_Format(tstate, PyExc_TypeError,
-                          "%T object is not iterable", iterator);
-        }
+    if (!Py_TYPE(iterable)->tp_iter && PyAsyncGen_CheckExact(iterable)) {
+        _PyErr_Format(tstate, PyExc_TypeError,
+                      "%T object is not iterable. Did you mean 'async yield from'?",
+                      iterable);
+        return NULL;
+    }
+    PyObject *iterator = PyObject_GetIter(iterable);
+    if (iterator == NULL) {
         return NULL;
     }
     yield_from->agyf_iterator = Py_NewRef(iterator);


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Previously, this wouldn't work:

```py
import asyncio

async def agen():
    yield from range(10)

async def main():
    [x async for x in agen()]  # ho ho is this a Prime reference

asyncio.run(main())
```

`PyObject_GetIter` increments iterable's refcount so I think we're game?
